### PR TITLE
Add description how to download Emotion classification models

### DIFF
--- a/Convert/download.sh
+++ b/Convert/download.sh
@@ -1,4 +1,8 @@
+# Age and gender models
 wget http://www.openu.ac.il/home/hassner/projects/cnn_agegender/cnn_age_gender_models_and_data.0.0.2.zip
 unzip -a cnn_age_gender_models_and_data.0.0.2.zip
-wget https://dl.dropboxusercontent.com/u/38822310/DemoDir.zip
-unzip -a DemoDir.zip
+
+# Emotions model
+# Download Caffe model: https://drive.google.com/open?id=0BydFau0VP3XSNVYtWnNPMU1TOGM
+# Download deploy.prototxt
+# Move the files to Covert/EmotionClassification

--- a/Convert/emotion.py
+++ b/Convert/emotion.py
@@ -1,6 +1,6 @@
 import coremltools
 
-folder = 'DemoDir/VGG_S_rgb'
+folder = 'EmotionClassification'
 
 coreml_model = coremltools.converters.caffe.convert(
     (folder + '/EmotiW_VGG_S.caffemodel', folder + '/deploy.prototxt'),

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ open Faces.xcworkspace/
 
 ## Conversion
 
+Download [Caffe model](https://drive.google.com/open?id=0BydFau0VP3XSNVYtWnNPMU1TOGM)
+and [deploy.prototxt](https://drive.google.com/open?id=0BydFau0VP3XSOFp4Ri1ITzZuUkk).
+Links can also be found [here](https://gist.github.com/GilLevi/54aee1b8b0397721aa4b#emotion-classification-cnn---rgb).
+Move downloaded files to `Covert/EmotionClassification` folder.
+
 ```sh
 cd Convert
 ./download.sh


### PR DESCRIPTION
Original Caffe files were moved to Google Drive and cannot be downloaded by `wget` anymore. There is a description how to download model and deploy.prototxt manually.